### PR TITLE
Cloud sync patch

### DIFF
--- a/bash/azuredevops/cloud-sync.yml
+++ b/bash/azuredevops/cloud-sync.yml
@@ -89,12 +89,13 @@ jobs:
       
       # Using plain git to try an push changes back to local repo
       # Depending on your setup you may need to change settings and permissions to better fit your needs
+      #  --ignore-space-change --ignore-whitespace on the git apply allows for minor changes due to OS environment.
       - pwsh: |
           Write-Host "hello branch: $($env:BUILD_SOURCEBRANCHNAME)"
           git checkout $env:BUILD_SOURCEBRANCHNAME
           git config --global user.name "Azure Pipeline"
           git config --global user.email "hosted.agent@dev.azure.com"
-          git apply -v $(gitPatchFile)
+          git apply -v $(gitPatchFile) --ignore-space-change --ignore-whitespace
           git add --all
           git commit -m "Adding cloud changes since deployment $(latestDeploymentId) [skip ci]"
           git push --set-upstream origin $env:BUILD_SOURCEBRANCHNAME

--- a/bash/github/cloud-sync.yml
+++ b/bash/github/cloud-sync.yml
@@ -95,6 +95,7 @@ jobs:
       # Depending on your setup you may need to change settings and permissions to better fit your needs
       # This targets the same branch as the pipeline was triggered on.
       # Stopping a new pipeline run by using the "[skip ci]" as part of commit message 
+      #  --ignore-space-change --ignore-whitespace on the git apply allows for minor changes due to OS environment.
       - name: Applying git patch to branch
         env:
           remoteChanges: ${{ needs.checkForChanges.outputs.remoteChanges }}
@@ -103,7 +104,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git apply ${{GITHUB.WORKSPACE}}/patch/git-patch.diff
+          git apply ${{GITHUB.WORKSPACE}}/patch/git-patch.diff --ignore-space-change --ignore-whitespace
           git add *
           git commit -m "Adding cloud changes since deployment ${{ env.latestDeploymentId }} [skip ci]"
           git push

--- a/powershell/azuredevops/cloud-sync.yml
+++ b/powershell/azuredevops/cloud-sync.yml
@@ -92,12 +92,13 @@ jobs:
       # Depending on your setup you may need to change settings and permissions to better fit your needs
       # This targets the same branch as the pipeline was triggered on.
       # Stopping a new pipeline run by using the "[skip ci]" as part of commit message 
+      #  --ignore-space-change --ignore-whitespace on the git apply allows for minor changes due to OS environment.
       - pwsh: |
           Write-Host "hello branch: $($env:BUILD_SOURCEBRANCHNAME)"
           git checkout $env:BUILD_SOURCEBRANCHNAME
           git config --global user.name "Azure Pipeline"
           git config --global user.email "hosted.agent@dev.azure.com"
-          git apply -v $(gitPatchFile)
+          git apply -v $(gitPatchFile) --ignore-space-change --ignore-whitespace
           git add --all
           git commit -m "Adding cloud changes since deployment $(latestDeploymentId) [skip ci]"
           git push --set-upstream origin $env:BUILD_SOURCEBRANCHNAME

--- a/powershell/github/cloud-sync.yml
+++ b/powershell/github/cloud-sync.yml
@@ -94,6 +94,7 @@ jobs:
       # Depending on your setup you may need to change settings and permissions to better fit your needs
       # This targets the same branch as the pipeline was triggered on.
       # Stopping a new pipeline run by using the "[skip ci]" as part of commit message 
+      #  --ignore-space-change --ignore-whitespace on the git apply allows for minor changes due to OS environment.
       - name: Applying git patch to branch
         env:
           remoteChanges: ${{ needs.checkForChanges.outputs.remoteChanges }}
@@ -102,7 +103,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git apply ${{GITHUB.WORKSPACE}}/patch/git-patch.diff
+          git apply ${{GITHUB.WORKSPACE}}/patch/git-patch.diff --ignore-space-change --ignore-whitespace
           git add *
           git commit -m "Adding cloud changes since deployment ${{ env.latestDeploymentId }} [skip ci]"
           git push


### PR DESCRIPTION
Adding ` --ignore-space-change --ignore-whitespace` to the `git apply` command in cloud-sync.yml enables the patch to be applied when the edits are made on, say, MacOS.  Without these switches, `git apply` aborts with "patch does not apply" errors.

This has been tested on two projects, one on DevOps and the other on github.  Prior to this change, both CI/CD environments failed to apply the patch if there were changes on the Cloud repository.

Note this will still fail of course if there are conflicts between the two environments.

I feel there is more work to be done to make this more robust; and on DevOps, the `Applying git patch to branch` step in the `ApplyRemoteChanges` job may fail and yet the deployment goes ahead anyway.  On github, this is enough to abort the deployment.