### PR TITLE
Make sure that the updated 'newSha' is picked up in Github Actions. 

### DIFF
--- a/V2/bash/github/main.yml
+++ b/V2/bash/github/main.yml
@@ -23,6 +23,8 @@ jobs:
     name: "Prepare and Upload Artifact"
     uses: ./.github/workflows/cloud-artifact.yml
     needs: cloud-sync
+    with:
+      newSha: ${{ needs.cloud-sync.outputs.newSha }}
     secrets:
       projectId: ${{ secrets.PROJECT_ID }}
       umbracoCloudApiKey: ${{ secrets.UMBRACO_CLOUD_API_KEY }}

--- a/V2/powershell/github/main.yml
+++ b/V2/powershell/github/main.yml
@@ -23,6 +23,8 @@ jobs:
     name: "Prepare and Upload Artifact"
     uses: ./.github/workflows/cloud-artifact.yml
     needs: cloud-sync
+    with:
+      newSha: ${{ needs.cloud-sync.outputs.newSha }}
     secrets:
       projectId: ${{ secrets.PROJECT_ID }}
       umbracoCloudApiKey: ${{ secrets.UMBRACO_CLOUD_API_KEY }}


### PR DESCRIPTION
Make sure that the outputs.newSha emitted in cloud-sync.yaml is passed into the cloud-artifact job.

Without this the sync stage runs and merges in the remote cloud changes, but then the next step will still attempt to deploy the version that triggered the action, which is now stale. 

I don't have the time to set up and test the devops versions, the yaml structure looks significantly different so perhaps this issue only effects Github Actions